### PR TITLE
change loss print output

### DIFF
--- a/train.py
+++ b/train.py
@@ -45,7 +45,6 @@ def save_model(model, saved_dir, file_name):
 
 
 def validation(epoch, num_epochs, model, data_loader, criterion, device):
-    print(f'Start validation #{epoch}')
     model.eval()
 
     example_images = []
@@ -93,10 +92,10 @@ def validation(epoch, num_epochs, model, data_loader, criterion, device):
             
             acc, acc_cls, mIoU, fwavacc, IoU = label_accuracy_score(hist)
             avrg_loss = total_loss / cnt
-            if (step + 1) % 1 == 0:
-                description = f'Validation #{epoch}  Average Loss: {round(avrg_loss.item(), 4)}' 
-                description += f', Accuracy : {round(acc, 4)}, mIoU: {round(mIoU, 4)}'
-                pbar.set_description(description)
+            
+            description = f'Validation #{epoch}  Average Loss: {round(avrg_loss.item(), 4)}' 
+            description += f', Accuracy : {round(acc, 4)}, mIoU: {round(mIoU, 4)}'
+            pbar.set_description(description)
 
         #IoU_by_class = [{classes : round(IoU,4)} for IoU, classes in zip(IoU , category_names)]
         IoU_by_class = [[c,IoU] for IoU,c in zip(IoU, category_names)]
@@ -161,12 +160,14 @@ def train(num_epochs, model, train_loader, val_loader, criterion, optimizer, sav
             
             hist = add_hist(hist, masks, outputs, n_class=n_class)
             acc, acc_cls, mIoU, fwavacc, IoU = label_accuracy_score(hist)
+           
+          
+            description =  f'Epoch [{epoch+1}/{num_epochs}], Step [{step+1}/{len(train_loader)}]: ' 
+            description += f'running Loss: {round(running_loss,4)}, mIoU: {round(mIoU,4)}'
+            pbar.set_description(description)
             
-            # step 주기에 따른 loss 출력
-            if (step + 1) % 1 == 0:
-                description =  f'Epoch [{epoch+1}/{num_epochs}], Step [{step+1}/{len(train_loader)}]: ' 
-                description += f'running Loss: {round(running_loss,4)}, mIoU: {round(mIoU,4)}'
-                pbar.set_description(description)
+            # step 주기에 따른 loss 출력(wadnb는 따로)
+            if (step + 1) % 25 == 0:
                 wandb.log(
                     {
                         "Train Loss": round(loss.item(), 4),


### PR DESCRIPTION
loss 출력 형태를 바꿔줬스빈다.
inference는 tqdm이 있어서 바꾸지 않고 train.py만 수정하였습니다.

Loss의 출력 형태를 바꿔주었습니다. 

- 한 epoch 걸리는 예측 시간 표시
- Batch 처리시간 x.xx s/it
- 줄이 넘어가지 않고 진행률 표시
- 줄이 넘어가지 않기에 출력 step 1로 변경
- validation안에서도 for문으로 출력문 넣어줌
    - 상관없다! 왜냐면 IoU자체 구하는게 누적이기 때문에
- Training 에서 Loss를 Running Loss로 출력
    - 학습과정에서는 배치 단위로 학습됨 따라서 앞의 로스와 뒤에로스간에 차이가나는데
    - 이를 단순히 평균을 내는것은 맞은것일까 고민
    - 그렇다고 배치단위로 로스를 출력하면 너무 널뛰니 전의 로스를 고려해서 현재로스의 값을 출력하도록 함
        
이미지 사진을 첨부하고 싶었는데 어떻게 하는지 모르곘어서 노션에 정리한것 첨부합니다!
https://www.notion.so/4294201fd33040c6a86f9d93a3d18cb1