### PR TITLE
Change the way models are named

### DIFF
--- a/train.py
+++ b/train.py
@@ -117,7 +117,7 @@ def validation(epoch, num_epochs, model, data_loader, criterion, device):
         
     return avrg_loss, mIoU
 
-def train(num_epochs, model, train_loader, val_loader, criterion, optimizer, saved_dir, val_every, save_mode, device, scheduler = None, fp16 = False):
+def train(num_epochs, model, train_loader, val_loader, criterion, optimizer, saved_dir, val_every, save_mode, device, scheduler = None, fp16 = False,cfgs=None):
     print(f'Start training..')
     n_class = 11
     best_loss = 9999999
@@ -198,7 +198,7 @@ def train(num_epochs, model, train_loader, val_loader, criterion, optimizer, sav
                     #save_dir = os.path.dirname(saved_dir)
                     if not os.path.exists(saved_dir):
                         os.makedirs(saved_dir)
-                    save_model(model, saved_dir, file_name=f"{model.model_name}_{best_loss}_{cur_date}.pt")
+                    save_model(model, saved_dir, file_name=f"{model.model_name}_{cfgs.wandb_run_name}_best_loss.pt")
                     
             else: # miou 기준 모델 저장
                 if miou > best_miou:
@@ -208,7 +208,7 @@ def train(num_epochs, model, train_loader, val_loader, criterion, optimizer, sav
                     #save_dir = os.path.dirname(saved_dir)
                     if not os.path.exists(saved_dir):
                         os.makedirs(saved_dir)
-                    save_model(model, saved_dir, file_name=f"{model.model_name}_{best_miou}_{cur_date}.pt")
+                    save_model(model, saved_dir, file_name=f"{model.model_name}_{cfgs.wandb_run_name}_best_miou.pt")
             
             # lr 조정
             if scheduler:
@@ -286,7 +286,7 @@ def main():
             print('There is no Scheduler!')
             scheduler = None
 
-    train(cfgs.num_epochs, model, train_dataloader, val_dataloader, criterion, optimizer, cfgs.saved_dir, cfgs.val_every, cfgs.save_mode, device, scheduler, cfgs.fp16)
+    train(cfgs.num_epochs, model, train_dataloader, val_dataloader, criterion, optimizer, cfgs.saved_dir, cfgs.val_every, cfgs.save_mode, device, scheduler, cfgs.fp16, cfgs=cfgs)
 
     wandb.run.finish()
 


### PR DESCRIPTION
이전에 issue에 올렸듯이 model을 저장한 .pt 파일의 파일명이 길고 복잡하고 많아져서 각각의 파일이 무엇을 의미하는지 잘 모르는 문제가 발생하여 임의대로 일단 cfgs.wandb_run_name대로 고쳐보면 좋지 않을까 싶어 PR 날립니다.
```
save_model(model, saved_dir, file_name=f"{model.model_name}_{cfgs.wandb_run_name}_best_loss.pt")
save_model(model, saved_dir, file_name=f"{model.model_name}_{cfgs.wandb_run_name}_best_miou.pt")
```
위와 같은 형식으로 저장됩니다.
만약 여러 모델을 저장하고 싶다면 count를 세면서 파일명을 변경하면 좋을 듯 합니다.