### PR TITLE
Fix error about dataset.mixup

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -184,8 +184,7 @@ class TrainDataset(Dataset):
         lst = []
         for i in range(img_size):
             lst.append(np.eye(11)[mask[i]])
-        mask = np.stack(lst)
-
+        mask = np.transpose(np.stack(lst), (2, 0, 1))
         return mask
 
 


### PR DESCRIPTION
mixup 사용 시, mask의 channel 축이 width와 height 보다 늦게 나오는 부분 수정
mask 출력 (batch, 512, 512, 11) -> (batch, 11, 512, 512)