### PR TITLE
[bug]  CopyPaste클래스 NotImplementedError 관련 코드 수정

### DIFF
--- a/copy_paste.py
+++ b/copy_paste.py
@@ -54,3 +54,6 @@ class CopyPaste(A.DualTransform):
         self.fn = self.train_df.iloc[self.idx]['file_name']
         self.new_img = cv2.imread(self.data_root + "/" + self.fn)
         self.seg = self.coco.annToMask(self.ann)
+
+    def get_transform_init_args_names(self):
+        return ()


### PR DESCRIPTION
현재 버전으로 class CopyPaste 사용시 아래와 같은 에러가 뜹니다.
![image](https://user-images.githubusercontent.com/43373175/138750025-9836ed73-a23e-41bc-8136-532eaa481a9f.png)

이는 get_transform_init_args_names이 구현되지 않아 생기는 에러로,
빈 tuple을 반환하게끔 코드를 수정했습니다.