### PR TITLE
minor fix to deformable convolutions

### DIFF
--- a/model.py
+++ b/model.py
@@ -291,7 +291,7 @@ class DeformableConv2d(nn.Module):
                                           weight=self.regular_conv.weight,
                                           bias=self.regular_conv.bias,
                                           padding=self.padding,
-                                          mask=self.modulator_conv,
+                                          mask=modulator,
                                           stride=self.stride)
             
         return x


### PR DESCRIPTION
minor fix

- handle "Type Error"
- deformable conv에 mask 인자를 넘겨줄 때 mask를 Tensor가 아닌 conv2d 객체를 넘겨주는 버그 해결