### PR TITLE
modify confusion matrix, class_IoU

### DIFF
--- a/train.py
+++ b/train.py
@@ -156,12 +156,7 @@ def validation(epoch, num_epochs, model, data_loader, criterion, device):
         "Validation mIoU": round(mIoU, 4)
     })
     
-    if epoch != num_epochs:
-        return avrg_loss, mIoU
-    else:
-        hist = hist.cpu().numpy()
-        return avrg_loss, mIoU, IoU_by_class, hist
-    
+    return avrg_loss, mIoU, IoU_by_class, hist    
     
 
 def train(num_epochs, model, train_loader, val_loader, criterion, optimizer, 
@@ -191,7 +186,7 @@ def train(num_epochs, model, train_loader, val_loader, criterion, optimizer,
         for step, (images, masks) in pbar:
             images = torch.stack(images).to(device)
             masks = torch.stack(masks).long().to(device) 
-  
+            
             optimizer.zero_grad()
             if fp16:
                 with autocast():
@@ -235,16 +230,15 @@ def train(num_epochs, model, train_loader, val_loader, criterion, optimizer,
              
         # validation 주기에 따른 loss 출력 및 best model 저장
         if (epoch + 1) % val_every == 0:
-            if epoch+1 < num_epochs:
-                avrg_loss, miou = validation(epoch+1, num_epochs, model, val_loader, criterion, device)
-            else:
-                avrg_loss, miou, class_iou, hist = validation(epoch+1, num_epochs, model, val_loader, criterion, device)
+            avrg_loss, miou, class_iou, hist = validation(epoch+1, num_epochs, model, val_loader, criterion, device)
             
             # save_mode에 따라 모델 저장
             if save_mode == "loss": # loss에 따라 모델 저장
                 if avrg_loss < best_loss:
                     print(f"Best performance at epoch: {epoch + 1}")
                     print(f"Save model in {saved_dir}")
+                    best_hist = hist.detach().cpu().numpy()
+                    best_class_iou = class_iou
                     best_loss = avrg_loss
                     save_checkpoint(epoch, model, best_loss, best_miou, optimizer, saved_dir, scheduler, file_name=f"{model.model_name}_{round(best_loss,3)}_{cur_date}.pt")
                     
@@ -252,6 +246,8 @@ def train(num_epochs, model, train_loader, val_loader, criterion, optimizer,
                 if miou > best_miou:
                     print(f"Best performance at epoch: {epoch + 1}")
                     print(f"Save model in {saved_dir}")
+                    best_hist = hist.detach().cpu().numpy()
+                    best_class_iou = class_iou
                     best_miou = miou
                     best_loss = avrg_loss # best miou일 때도 loss tracking 수행 후 checkpoint에 저장
                     save_checkpoint(epoch, model, best_loss, best_miou, optimizer, saved_dir, scheduler, file_name=f"{model.model_name}_{round(best_miou, 3)}_{cur_date}.pt")
@@ -263,10 +259,10 @@ def train(num_epochs, model, train_loader, val_loader, criterion, optimizer,
                 else:
                     scheduler.step()
 
-    #heatmap    
+    #heatmap
     ax = plt.subplots(figsize=(12,12))
     heatmap_labels = [category_dicts[key] + "("+str(key)+")" for key in category_dicts]
-    ax = sns.heatmap(hist/np.sum(hist, axis=1).reshape(-1,1), xticklabels = heatmap_labels, yticklabels = heatmap_labels,  
+    ax = sns.heatmap(best_hist/np.sum(best_hist, axis=1).reshape(-1,1), xticklabels = heatmap_labels, yticklabels = heatmap_labels,  
                      annot = True, cmap = 'Blues', fmt = ".4f") # gt 중에서 해당 prediction이 차지하는 비율이 얼마나 되는지
     ax.tick_params(axis='x', rotation=30)
     ax.set_title("Confusion Matrix for the latest results")
@@ -276,7 +272,7 @@ def train(num_epochs, model, train_loader, val_loader, criterion, optimizer,
     wandb.log(
         {
             "Confusion Matrix": wandb.Image(ax),
-            "IoU by Class": wandb.plot.bar(wandb.Table(data=class_iou, columns=["label","value"]), "label","value", title="IoU by class")
+            "IoU by Class": wandb.plot.bar(wandb.Table(data=best_class_iou, columns=["label","value"]), "label","value", title="IoU by class")
         }
     )
 


### PR DESCRIPTION
confusion matrix와 class별 Iou를 wandb에서 best를 기준으로 그래프를 그리도록 수정하였습니다.

기존에 validation 부분에서 연산  되는 것을 항상 리턴하도록 바꿔준거라 계산량에서는 차이가 안날것 같습니다.

메모리 측면에서는 기존 코드에서 hist를(11x11 array)이랑 class IoU(list)만 새로 생성하는데 데이터 크기가 작아서 큰 차이가 없지 않을까요...? 생각됩니다 혹시라도 잘못된 부분있거나 다른 의견 있으시면 말씀해주세요~!