### PR TITLE
train resume_mode

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,13 +65,14 @@ def save_checkpoint(epoch, model, loss, miou, optimizer, saved_dir, scheduler, f
     output_path = os.path.join(saved_dir, file_name)
     torch.save(check_point, output_path)
 
-def load_checkpoint(checkpoint_path, model, optimizer, scheduler):
+def load_checkpoint(checkpoint_path, model, optimizer, scheduler, mode):
     # load model if resume_from is set
     checkpoint = torch.load(checkpoint_path)
     model.load_state_dict(checkpoint['net'])
-    optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-    if scheduler:
-        scheduler.load_state_dict(checkpoint['scheduler_state_dict'])
+    if mode =="all":
+        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+        if scheduler:
+            scheduler.load_state_dict(checkpoint['scheduler_state_dict'])
     start_epoch = checkpoint['epoch']
     start_loss = checkpoint['loss']
     prv_best_miou = checkpoint['miou']
@@ -159,7 +160,7 @@ def validation(epoch, num_epochs, model, data_loader, criterion, device):
     
 
 def train(num_epochs, model, train_loader, val_loader, criterion, optimizer, 
-          saved_dir, val_every, save_mode, resume_from, checkpoint_path, 
+          saved_dir, val_every, save_mode, resume_from, resume_mode, checkpoint_path, 
           num_to_remain, device, scheduler = None, fp16 = False):
 
     print(f'Start training..')
@@ -170,7 +171,7 @@ def train(num_epochs, model, train_loader, val_loader, criterion, optimizer,
     num_to_remain = 3 # remain 3 files
 
     if resume_from:
-        model, optimizer, scheduler, start_epoch, best_loss, best_miou = load_checkpoint(checkpoint_path, model, optimizer, scheduler)
+        model, optimizer, scheduler, start_epoch, best_loss, best_miou = load_checkpoint(checkpoint_path, model, optimizer, scheduler, resume_mode)
     
     if fp16:
         print("Mixed precision is applied")
@@ -362,7 +363,8 @@ def main():
         'saved_dir': saved_dir, 
         'val_every': cfgs.val_every, 
         'save_mode': cfgs.save_mode, 
-        'resume_from': cfgs.resume_from, 
+        'resume_from': cfgs.resume_from,
+        'resume_mode': cfgs.resume_mode, 
         'checkpoint_path': cfgs.checkpoint_path, # absolute path
         'num_to_remain': cfgs.num_to_remain,
         'device': device,

--- a/train_config.json
+++ b/train_config.json
@@ -31,6 +31,7 @@
               "args" : {"num_classes" : 11,
                         "target_size" : 512}},
     "resume_from": false,
+    "resume_mode": "all",
     "checkpoint_path": "",
 
     "criterion": {"name" : "DiceCELoss",


### PR DESCRIPTION
### 이슈
모델 체크포인트로부터 재학습 시 optimizer, scheduler를 변경하고자 할 때 기존의 load_checkpoint 함수에서 에러 발생.

### 해결
1. train_config.json에서 resume_mode를 추가하여 all 또는 model을 입력함으로써 원하는 resume mode를 설정할 수 있도록 함.
2. train.py에서 load_checkpoint 함수에 resume_mode를 인자로 더해주어 함수 내에서 모드를 제어 가능하게 함.

