### PR TITLE
ignore jupyternotebook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# ignore jupyternotebook
+*.ipynb linguist-documentation


### PR DESCRIPTION
jupyter notebook을 github에서 count하지 않도록 하기 위해 .gitattributes 파일 추가